### PR TITLE
Implement iterative vtable policy resolution

### DIFF
--- a/example/vtable_traits.cpp
+++ b/example/vtable_traits.cpp
@@ -62,9 +62,7 @@ private:
     dyno::local<dyno::only<
       decltype("increment"_s), decltype("equal"_s), decltype("dereference"_s)
     >>,
-    dyno::remote<dyno::except<
-      decltype("increment"_s), decltype("equal"_s), decltype("dereference"_s)
-    >>
+    dyno::remote<dyno::everything_else>
   >;
   dyno::poly<Concept, Storage, VTable> poly_;
 

--- a/test/vtable.fail.1.cpp
+++ b/test/vtable.fail.1.cpp
@@ -22,6 +22,6 @@ int main() {
     dyno::complete_concept_map<Fooable, int>(dyno::concept_map<Fooable, int>)
   };
 
-  // MESSAGE[Request for a virtual function that is not in the vtable]
+  // MESSAGE[Request for a virtual function that is not present in any of the joined vtables]
   auto bar = vtable["bar"_s];
 }

--- a/test/vtable.fail.3.cpp
+++ b/test/vtable.fail.3.cpp
@@ -1,0 +1,29 @@
+// Copyright Louis Dionne 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <dyno/concept.hpp>
+#include <dyno/concept_map.hpp>
+#include <dyno/vtable.hpp>
+using namespace dyno::literals;
+
+
+struct Concept : decltype(dyno::requires(
+  "f"_s = dyno::function<void (dyno::T const&)>,
+  "g"_s = dyno::function<void (dyno::T const&)>
+)) { };
+
+struct Foo { };
+
+template <>
+auto const dyno::concept_map<Concept, Foo> = dyno::make_concept_map(
+  "f"_s = [](Foo&) { },
+  "g"_s = [](Foo&) { }
+);
+
+int main() {
+  auto complete = dyno::complete_concept_map<Concept, Foo>(dyno::concept_map<Concept, Foo>);
+
+  // MESSAGE[The policies specified in the vtable did not fully cover all the functions provided by the concept]
+  dyno::vtable<dyno::local<dyno::only<decltype("f"_s)>>>::apply<Concept> vtable{complete};
+}

--- a/test/vtable.fail.4.cpp
+++ b/test/vtable.fail.4.cpp
@@ -1,0 +1,30 @@
+// Copyright Louis Dionne 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <dyno/concept.hpp>
+#include <dyno/concept_map.hpp>
+#include <dyno/vtable.hpp>
+using namespace dyno::literals;
+
+
+struct Concept : decltype(dyno::requires(
+  "f"_s = dyno::function<void (dyno::T const&)>
+)) { };
+
+struct Foo { };
+
+template <>
+auto const dyno::concept_map<Concept, Foo> = dyno::make_concept_map(
+  "f"_s = [](Foo&) { }
+);
+
+int main() {
+  auto complete = dyno::complete_concept_map<Concept, Foo>(dyno::concept_map<Concept, Foo>);
+
+  // MESSAGE[Some functions specified in this selector are not part of the concept to which the selector was applied]
+  dyno::vtable<
+    dyno::local<dyno::only<decltype("nonexistent"_s)>>,
+    dyno::remote<dyno::everything_else>
+  >::apply<Concept> vtable{complete};
+}

--- a/test/vtable.fail.5.cpp
+++ b/test/vtable.fail.5.cpp
@@ -1,0 +1,30 @@
+// Copyright Louis Dionne 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <dyno/concept.hpp>
+#include <dyno/concept_map.hpp>
+#include <dyno/vtable.hpp>
+using namespace dyno::literals;
+
+
+struct Concept : decltype(dyno::requires(
+  "f"_s = dyno::function<void (dyno::T const&)>
+)) { };
+
+struct Foo { };
+
+template <>
+auto const dyno::concept_map<Concept, Foo> = dyno::make_concept_map(
+  "f"_s = [](Foo&) { }
+);
+
+int main() {
+  auto complete = dyno::complete_concept_map<Concept, Foo>(dyno::concept_map<Concept, Foo>);
+
+  // MESSAGE[Some functions specified in this selector are not part of the concept to which the selector was applied]
+  dyno::vtable<
+    dyno::local<dyno::except<decltype("nonexistent"_s)>>,
+    dyno::remote<dyno::everything_else>
+  >::apply<Concept> vtable{complete};
+}


### PR DESCRIPTION
The idea is that vtable policies should be aware of policies that come before them. This way, we can replace

```c++
te::vtable<
  te::local<te::only<decltype("foo"_s)>>,
  te::remote<te::except<decltype("foo"_s)>>
>
```

by simply

```c++
te::vtable<
  te::local<te::only<decltype("foo"_s)>>,
  te::remote<te::everything>
>
```