### PR TITLE
Selectors accept actual compile-time strings

### DIFF
--- a/example/vtable_traits.cpp
+++ b/example/vtable_traits.cpp
@@ -59,9 +59,7 @@ private:
   using Concept = Iterator<reference>;
   using Storage = dyno::remote_storage;
   using VTable = dyno::vtable<
-    dyno::local<dyno::only<
-      decltype("increment"_s), decltype("equal"_s), decltype("dereference"_s)
-    >>,
+    dyno::local<dyno::only<"increment"_s, "equal"_s, "dereference"_s>>,
     dyno::remote<dyno::everything_else>
   >;
   dyno::poly<Concept, Storage, VTable> poly_;

--- a/include/dyno/detail/dsl.hpp
+++ b/include/dyno/detail/dsl.hpp
@@ -104,6 +104,9 @@ namespace detail {
       return detail::delayed_call<string, Args&&...>{std::forward<Args>(args)...};
     }
 
+    static constexpr char storage_[] = {c..., '\0'};
+    constexpr operator char const*() const { return storage_; }
+
     using hana_tag = typename boost::hana::tag_of<boost::hana::string<c...>>::type;
   };
 
@@ -114,6 +117,21 @@ namespace detail {
   template <typename S>
   constexpr auto prepare_string(S) {
     return detail::prepare_string_impl<S>(std::make_index_sequence<S::size()>{});
+  }
+
+  constexpr std::size_t constexpr_strlen(char const* s) {
+    std::size_t len = 0;
+    while (*s++ != '\0') ++len;
+    return len;
+  }
+
+  template <char const* s>
+  constexpr auto make_string() {
+    struct tmp {
+        static constexpr std::size_t size() { return detail::constexpr_strlen(s); }
+        static constexpr char const* get() { return s; }
+    };
+    return detail::prepare_string(tmp{});
   }
 } // end namespace detail
 

--- a/include/dyno/vtable.hpp
+++ b/include/dyno/vtable.hpp
@@ -6,6 +6,7 @@
 #define DYNO_VTABLE_HPP
 
 #include <dyno/concept.hpp>
+#include <dyno/detail/dsl.hpp>
 #include <dyno/detail/erase_function.hpp>
 #include <dyno/detail/erase_signature.hpp>
 
@@ -208,11 +209,11 @@ private:
 
 //////////////////////////////////////////////////////////////////////////////
 // Selectors
-template <typename ...Functions>
+template <char const* ...Functions>
 struct only {
   template <typename All>
   constexpr auto operator()(All all) const {
-    auto matched = boost::hana::make_set(Functions{}...);
+    auto matched = boost::hana::make_set(detail::make_string<Functions>()...);
     static_assert(decltype(boost::hana::is_subset(matched, all))::value,
       "dyno::only: Some functions specified in this selector are not part of "
       "the concept to which the selector was applied.");
@@ -223,11 +224,11 @@ struct only {
   }
 };
 
-template <typename ...Functions>
+template <char const* ...Functions>
 struct except {
   template <typename All>
   constexpr auto operator()(All all) const {
-    auto not_matched = boost::hana::make_set(Functions{}...);
+    auto not_matched = boost::hana::make_set(detail::make_string<Functions>()...);
     static_assert(decltype(boost::hana::is_subset(not_matched, all))::value,
       "dyno::except: Some functions specified in this selector are not part of "
       "the concept to which the selector was applied.");
@@ -251,12 +252,12 @@ namespace detail {
   template <typename T>
   struct is_valid_selector : boost::hana::false_ { };
 
-  template <typename ...Methods>
+  template <char const* ...Methods>
   struct is_valid_selector<dyno::only<Methods...>>
     : boost::hana::true_
   { };
 
-  template <typename ...Methods>
+  template <char const* ...Methods>
   struct is_valid_selector<dyno::except<Methods...>>
     : boost::hana::true_
   { };
@@ -389,12 +390,12 @@ constexpr auto generate_vtable(Policies policies) {
 // cumbersome. Selectors provided by the library are:
 //
 //  dyno::only<functions...>
-//    Picks only the specified functions from a concept. `functions` must be
-//    compile-time strings, such as `dyno::only<decltype("foo"_s), decltype("bar"_s)>`.
+//    Picks only the specified functions from a concept. `functions...` must
+//    be compile-time strings, such as `dyno::only<"foo"_s, "bar"_s>`.
 //
 //  dyno::except<functions...>
-//    Picks all but the specified functions from a concept. `functions` must
-//    be compile-time strings, such as `dyno::except<decltype("foo"_s), decltype("bar"_s)>`.
+//    Picks all but the specified functions from a concept. `functions...`
+//    must be compile-time strings, such as `dyno::except<"foo"_s, "bar"_s>`.
 //
 //  dyno::everything
 //    Picks all the functions from a concept.

--- a/test/detail/dsl.make_string.cpp
+++ b/test/detail/dsl.make_string.cpp
@@ -1,0 +1,28 @@
+// Copyright Louis Dionne 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <dyno/detail/dsl.hpp>
+
+#include <type_traits>
+
+
+int main() {
+  {
+    static constexpr char const s[] = "";
+    static_assert(std::is_same<decltype(dyno::detail::make_string<s>()),
+                               dyno::detail::string<>>{});
+  }
+
+  {
+    static constexpr char const s[] = "a";
+    static_assert(std::is_same<decltype(dyno::detail::make_string<s>()),
+                               dyno::detail::string<'a'>>{});
+  }
+
+  {
+    static constexpr char const s[] = "abc";
+    static_assert(std::is_same<decltype(dyno::detail::make_string<s>()),
+                               dyno::detail::string<'a', 'b', 'c'>>{});
+  }
+}


### PR DESCRIPTION
It is possible to forego the `decltype` step when using selectors, giving:

```c++
dyno::only<"foo"_s, "bar"_s>
```

instead of

```c++
dyno::only<decltype("foo"_s), decltype("bar"_s)>
```

To do this, we only need to add an implicit conversion to `char const*` to the literal type created by the `_s` literal. [live example](https://wandbox.org/permlink/dcO9k5FF9WBM6mK0). Unfortunately, this is not supported by GCC 7, which is the only compiler I have locally that can actually build Dyno. So I'll wait a bit before making the change.
