### PR TITLE
Ensuring that poly<C, non_owning_storage, V> is trivially copyable.

### DIFF
--- a/include/dyno/storage.hpp
+++ b/include/dyno/storage.hpp
@@ -474,34 +474,15 @@ public:
 // does not construct or destruct it. The referenced object must outlive the
 // polymorphic storage that references it, otherwise the behavior is undefined.
 struct non_owning_storage {
-  non_owning_storage() = delete;
-  non_owning_storage(non_owning_storage const&) = delete;
-  non_owning_storage(non_owning_storage&&) = delete;
-  non_owning_storage& operator=(non_owning_storage&&) = delete;
-  non_owning_storage& operator=(non_owning_storage const&) = delete;
+  non_owning_storage(non_owning_storage const&) = default;
+  non_owning_storage(non_owning_storage&&) = default;
+  non_owning_storage& operator=(non_owning_storage&&) = default;
+  non_owning_storage& operator=(non_owning_storage const&) = default;
 
   template <typename T>
   explicit non_owning_storage(T& t)
     : ptr_{&t}
   { }
-
-  template <typename VTable>
-  non_owning_storage(non_owning_storage const& other, VTable const&)
-    : ptr_{other.ptr_}
-  { }
-
-  template <typename VTable>
-  non_owning_storage(non_owning_storage&& other, VTable const&)
-    : ptr_{other.ptr_}
-  { }
-
-  template <typename MyVTable, typename OtherVTable>
-  void swap(MyVTable const&, non_owning_storage& other, OtherVTable const&) {
-    std::swap(this->ptr_, other.ptr_);
-  }
-
-  template <typename VTable>
-  void destruct(VTable const&) { }
 
   template <typename T = void>
   T* get() {

--- a/test/poly.non_owning_storage.trivial.cpp
+++ b/test/poly.non_owning_storage.trivial.cpp
@@ -1,0 +1,27 @@
+// Copyright Louis Dionne 2017
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <type_traits>
+#include <dyno/concept.hpp>
+#include <dyno/poly.hpp>
+#include <dyno/storage.hpp>
+#include "testing.hpp"
+
+struct Concept : decltype(dyno::requires()) { };
+struct Foo { };
+
+int main() {
+  using P = dyno::poly<Concept, dyno::non_owning_storage>;
+  static_assert(std::is_trivially_copyable<P>{}, "!");
+
+  Foo f;
+  P p1(f);
+  DYNO_CHECK(p1.unsafe_get<Foo>() == &f);
+  P p2 = p1; 
+  DYNO_CHECK(p1.unsafe_get<Foo>() == &f);
+  DYNO_CHECK(p2.unsafe_get<Foo>() == &f);
+  P p3 = std::move(p1);
+  DYNO_CHECK(p1.unsafe_get<Foo>() == &f);
+  DYNO_CHECK(p3.unsafe_get<Foo>() == &f);
+}


### PR DESCRIPTION
This is the boring boilerplate bullshit that makes it possible for `poly<C, non_owning_storage>` to be trivially copyable - which is just a nice thing in certain contexts. There are more steps to take to improve this (i.e. there are several concepts that make no sense to type erase for `non_owning_storage` and we can just remove them), so this is just the first go. 